### PR TITLE
[Feat] STT API 구현 #39

### DIFF
--- a/src/service/langserve/app/server.py
+++ b/src/service/langserve/app/server.py
@@ -4,11 +4,14 @@ from pydantic 			import BaseModel, Field
 from typing				import List, Union
 from langchain.schema	import AIMessage, HumanMessage, SystemMessage
 from app.chain			import ChainV1, ChainV2, ChainV3
+from app.stt			import Stt
 from bson 				import ObjectId
 
 app = FastAPI(title = "LLMChain", description = "Large Language Model Chain", version = "0.1.0")
 
 models_dict = {}
+
+stt_set = Stt()
 
 # Pydantic 모델에서 ObjectId를 사용하기 위한 클래스
 class PyObjectId(ObjectId):
@@ -37,6 +40,12 @@ class ChatRequest(BaseModel):
 
 class ChatResponse(BaseModel):
 	content: str
+
+class STTRequest(BaseModel):
+    file: bytes
+
+class STTResponse(BaseModel):
+	text: str
 
 @app.post("/v1/chat/connect", response_model=ChatResponse)
 async def connect_v1(request : ConnectRequest):
@@ -85,6 +94,11 @@ async def chatV2(request: ChatRequest):
 @app.post("/v3/chat/invoke", response_model=ChatResponse)
 async def chatV2(request: ChatRequest):
 	return ChatResponse(content=models_dict[request.history_id](request.content)['text'])
+
+#stt api
+@app.post("/chat/stt", response_model=STTResponse)
+async def stt(request: STTRequest):
+	return ChatResponse(text = stt_set.execution(request.file))
 
 
 

--- a/src/service/langserve/app/stt/___init__.py
+++ b/src/service/langserve/app/stt/___init__.py
@@ -1,0 +1,16 @@
+import openai
+from pydub import AudioSegment
+
+class stt:
+    def __init__(self) :
+        self.client = openai.OpenAI()
+    def execution(self, audio_file_name):
+        audio_file = open('audio_file_name', 'rb')
+
+        self.transcript = self.client.audio.transcriptions.create(
+                        model='whisper-1',
+                        file=audio_file,
+                        response_format='text'
+                    )
+        
+        return self.transcript

--- a/src/service/langserve/app/stt/__init__.py
+++ b/src/service/langserve/app/stt/__init__.py
@@ -1,11 +1,12 @@
 import openai
 from pydub import AudioSegment
 
-class stt:
+class Stt:
     def __init__(self) :
         self.client = openai.OpenAI()
-    def execution(self, audio_file_name):
-        audio_file = open('audio_file_name', 'rb')
+        
+    def execution(self, audio_file):
+        # audio_file = open('audio_file_name', 'rb')
 
         self.transcript = self.client.audio.transcriptions.create(
                         model='whisper-1',

--- a/src/service/langserve/poetry.lock
+++ b/src/service/langserve/poetry.lock
@@ -1243,6 +1243,17 @@ dotenv = ["python-dotenv (>=0.10.4)"]
 email = ["email-validator (>=1.0.3)"]
 
 [[package]]
+name = "pydub"
+version = "0.25.1"
+description = "Manipulate audio with an simple and easy high level interface"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pydub-0.25.1-py2.py3-none-any.whl", hash = "sha256:65617e33033874b59d87db603aa1ed450633288aefead953b30bded59cb599a6"},
+    {file = "pydub-0.25.1.tar.gz", hash = "sha256:980a33ce9949cab2a569606b65674d748ecbca4f0796887fd6f46173a7b0d30f"},
+]
+
+[[package]]
 name = "pygments"
 version = "2.17.2"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -2030,4 +2041,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8268f237cda58371a9953aef665135c1880c887928ee15d8d603bab6e07a811f"
+content-hash = "1d66e36267502adc5fc128c9094165bbc92d2a2104a61a0a34a4ea3b209da278"

--- a/src/service/langserve/pyproject.toml
+++ b/src/service/langserve/pyproject.toml
@@ -18,6 +18,7 @@ python-decouple = "^3.8"
 python-dotenv = "^1.0.1"
 faiss-cpu = "^1.8.0"
 pymongo = "^4.6.2"
+pydub = "^0.25.1"
 
 [tool.poetry.group.dev.dependencies]
 langchain-cli = ">=0.0.15"


### PR DESCRIPTION
## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
 - stt api를 구현했습니다.
## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
 - open api의 wishper model을 사용했습니다.
 - api 경로는 /chat/stt로 생성했습니다.
 - return type은 string입니다.
 - request에서는 bytes를 받아오게 하여 음성 파일을 받도록 했습니다.
## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
 -