### PR TITLE
[Secure] Mitigating DDoS Attacks with NGINX #210

### DIFF
--- a/src/service/nginx/conf/default.conf
+++ b/src/service/nginx/conf/default.conf
@@ -6,14 +6,36 @@ upstream nestjs {
 	server nestjs:nestjs_port;
 }
 
+geo $block_china {
+    default 0;
+
+		# 2024 등록된 중국 IP 대역
+		157.15.200.0/23 1;
+		157.10.218.0/23 1;
+		157.10.220.0/23 1;
+		157.20.136.0/23 1;
+}
 server {
 	listen 80;
 	listen [::]:80;
 
 	server_name my_domain dev.my_domain;
+	# 중국 IP 차단
+	if ($block_china) {
+			return 403;
+	}
+
+	#  Slowloris가 이러한 유형의 공격 대응으로 timeout 설정 : default 60s -> 10s
+	client_body_timeout 10s;
+	client_header_timeout 10s;
 
 	return 301 https://$host$request_uri;
 }
+
+# NextJS setting for ddos protection
+limit_req_zone $binary_remote_addr zone=ddos_req_search_diary:10m rate=5r/s;
+limit_req_zone $binary_remote_addr zone=ddos_req_album:10m rate=30r/s;
+limit_req_zone $binary_remote_addr zone=ddos_req_search:40m rate=40r/s;
 
 server {
 	listen 443 ssl;
@@ -34,7 +56,45 @@ server {
 		proxy_set_header Host $host;
 		proxy_cache_bypass $http_upgrade;
 	}
+
+	location /album {
+		proxy_pass http://nextjs;
+		proxy_http_version 1.1;
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header Connection 'upgrade';
+		proxy_set_header Host $host;
+		proxy_cache_bypass $http_upgrade;
+
+		limit_req zone=ddos_req_album;
+	}
+
+	location /search {
+		proxy_pass http://nextjs;
+		proxy_http_version 1.1;
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header Connection 'upgrade';
+		proxy_set_header Host $host;
+		proxy_cache_bypass $http_upgrade;
+
+		limit_req zone=ddos_req_search;
+	}
+
+	location /search/diary/ {
+		proxy_pass http://nextjs;
+		proxy_http_version 1.1;
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header Connection 'upgrade';
+		proxy_set_header Host $host;
+		proxy_cache_bypass $http_upgrade;
+		
+		limit_req zone=ddos_req_search_diary;
+	}
+
+
 }
+
+# NestJS setting for ddos protection
+limit_req_zone $binary_remote_addr zone=ddos_req_mysticConnect:10m rate=10r/s;
 
 server {
 	listen 443 ssl;
@@ -54,5 +114,16 @@ server {
 		proxy_set_header Connection 'upgrade';
 		proxy_set_header Host $host;
 		proxy_cache_bypass $http_upgrade;
+	}
+
+	location /mystic/connect {
+		proxy_pass http://nestjs;
+		proxy_http_version 1.1;
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header Connection 'upgrade';
+		proxy_set_header Host $host;
+		proxy_cache_bypass $http_upgrade;
+
+		limit_req zone=ddos_req_mysticConnect burst=10 nodelay;
 	}
 }


### PR DESCRIPTION
## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
 - close #210 
## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
- Distributed Denial-of-Service(DDoS) 공격은 리소스 부족으로 인해 서비스를 제공하는 서버가 더 이상 정상적으로 작동할 수 없을 정도로 여러 컴퓨터에서 대량의 트래픽을 발생시켜 서비스를 사용할 수 없게 만들려고 시도하는 공격이다.

- 일반적으로 공격자는 너무 많은 연결과 요청으로 시스템을 과부화 시켜 더 이상 새로운 트래픽을 수용할 수 없거나 속도가 너무 느려져 사실상 사용할 수 없게 만들려고 시도한다.

- NGINX에서는 들어오는 요청을 허용하는 속도를 실제 사용자에게 나타나는 일반적인 값으로 제한할 수 있다. 예를 들어 로그인 페이지에 액세스하는 실제 사용자는 2초마다 한 번만 요청할 수 있도록 설정할 수 있다.
- 또한 특정 IP에대한 접근을 deny 할 수 있다.
- 데이터 쓰는 빈도가 너무 낮은 연결을 연결 해제할 수 있는데, 이는 연결을 가능한 한 오래 열어두려는 시도일 수 있다. 따라서 서버가 새 연결을 수락하는 기능이 저하된다. Slowloris가 이러한 유형의 공격의 한 예이다. client_body_timeout 값은 클라이언트 본문의 쓰기 사이에 NGINX가 대기하는 시간을 제어하고, client_header_timeout 값은 클라이언트 헤더의 쓰기 사이에 NGINX가 대기하는 시간을 제어한다. 두 기본값은 60초이다.

1. nextjs - /search, /album, /search/diary/ 경로 요청 값 설정
2. nestjs - /mystic/connect 경로 요청 값 설정
3. 최근 등록된 특정 해외 IP 대역 deny 설정
4. Slowloris가 이러한 유형의 공격 대응으로 timeout(client_body, client_header) 설정 : default 60s -> 10s

## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
 -